### PR TITLE
Added redirected URI parameter

### DIFF
--- a/authorization.adoc
+++ b/authorization.adoc
@@ -40,7 +40,7 @@ http://httpbin.org/get?code=4fa87ba8cc7f30e91ad2ab1ad21c1b3e&state=XFadwMEXCJGJU
 ```
 
 #### The redirect_uri parameter
-The `redirect_uri` parameter is to the application URI, where the user is to be redirected after they have authorized the partner application. The redirected URI must be one of the URIs, registered to the designated partner.
+The 'redirect_uri' parameter is provided by the partner and is where the user will be redirected after a successful authorization. Only URIs registered with the partner application are allowed.
 
 #### The state parameter
 The `state` parameter is required for security reasons. You should set it to a random unique value for each request (a nonce), and then verify that the redirect URI contains the same value.

--- a/authorization.adoc
+++ b/authorization.adoc
@@ -22,13 +22,13 @@ The production environment is hosted at https://oauth.izettle.net.
 Once the partner is registered and has received a secret and client id (uuid) it can present the user with a link to authorize the partners access to the users data,
 this link is opened up in a web browser:
 ```
-{{URL}}/authorize?response_type=code&client_id=c55de605-48b6-42ef-b69e-cd9d14ded15a&scope=READ:FINANCE%20READ:PURCHASE
+{{URL}}/authorize?response_type=code&client_id=c55de605-48b6-42ef-b69e-cd9d14ded15a&scope=READ:FINANCE%20READ:PURCHASE&redirect_uri=https://httpbin.org/get
 ```
 
 If the user doesn't have a valid SSO token cookie, the user is forced to login. When authenticated the
 user is presented with a screen where the partner info is displayed, along with the requested authorization scope.
 
-To allow the authorization, the user will invoke the authorization URL above with an extra query parameter `action=authorize`.
+To allow the authorization, the user will press the _Approve_ button, thus invoking the authorization URL above with an extra query parameter `action=authorize`.
 ```
 curl --write-out %{redirect_url} -s \
 -H 'Cookie: iz_sso=9c3375c9-fd1b-4fde-9743-6f3d2e475388' \
@@ -38,6 +38,9 @@ The server responds with a redirect to the redirect URI that the partner has pro
 ```
 http://httpbin.org/get?code=4fa87ba8cc7f30e91ad2ab1ad21c1b3e&state=XFadwMEXCJGJUfD
 ```
+
+#### The redirect_uri parameter
+The `redirect_uri` parameter is to the application URI, where the user is to be redirected after they have authorized the partner application. The redirected URI must be one of the URIs, registered to the designated partner.
 
 #### The state parameter
 The `state` parameter is required for security reasons. You should set it to a random unique value for each request (a nonce), and then verify that the redirect URI contains the same value.


### PR DESCRIPTION
Based on the support request from the StuccoMedia. I updated the documentation to clarify that 

- The request_URI parameter must be provided
- It must be one of the URI that are registered to the partner application
- The end user will authorize the connection by click the "Approve" button.