### PR TITLE
Added a sub page for product library with link to swagger doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
  - [OAuth](authorization.adoc)
  - [Finance](finance.adoc)
  - [Purchase](purchase.adoc)
- - [Product Library](https://products.izettle.com/swagger)
+ - [Product Library](product-library.adoc)

--- a/product-library.adoc
+++ b/product-library.adoc
@@ -1,0 +1,12 @@
+## Product Library API
+
+### URL
+Production:: https://products.izettle.com
+
+### Description
+The product library API provides information about a merchant's products. Currently the API is only available in the production environment requiring production credentials to access.
+
+A test environment will be made available soon, in the mean time integrators with production credentials can try out the API by creating their own iZettle account and add products to their product library.
+
+### Documentation
+API documentation can be found here: https://products.izettle.com/swagger


### PR DESCRIPTION
The sub page informs the reader that product library currently only exists in the prod environment.