### PR TITLE
fix some spelling and add clarifications

### DIFF
--- a/finance.adoc
+++ b/finance.adoc
@@ -59,7 +59,7 @@ FEE_DISCOUNT_REVOCATION::: An internal reclaim of outstanding fee discount money
 CARD_PAYMENT_FEE::: References the commission part of a card payment.
 CARD_PAYMENT_FEE_REFUND::: References the commission part of a refund.
 ADVANCE::: References the cash advance given by iZettle to a merchant.
-A cash advance is a type of financing that is offered to merchant's based on their sales history. The advance is paid back with monthly down payment.
+A cash advance is a type of financing that is offered to merchant's based on their sales history. The advance is paid back with monthly down payments.
 ADVANCE_FEE::: References the fee that iZettle charges when giving a cash advance.
 ADVANCE_DOWNPAYMENT::: A down payment on a previously paid out cash advance.
 ADVANCE_FEE_DOWNPAYMENT::: References the netting of a cash advance fee.

--- a/finance.adoc
+++ b/finance.adoc
@@ -15,7 +15,7 @@ https://finance.izettle.com/swagger
 The endpoints below can be called for either the `LIQUID` or `PRELIMINARY` account type groups. The `LIQUID` group contains transactions that has been cleared and is typically what is useful for an external integrator. The `PRELIMINARY` group contains transactions that are waiting to be cleared and there can exist several transactions for one single card payment in this group due to internal account movements.
 
 ### Account Balance
-`GET organizations/us/accounts/{accountTypeGroup}/balance`
+`GET /organizations/us/accounts/{accountTypeGroup}/balance`
 
 accountTypeGroup:: Which accounts types to get data from. Either `LIQUID` or `PRELIMINARY`.
 until (optional):: used to get the balance at a specific point in history (ignoring any later transactions).
@@ -24,7 +24,7 @@ until (optional):: used to get the balance at a specific point in history (ignor
 `READ:FINANCE`
 
 #### Example Response
-`GET organizations/us/accounts/PRELIMINARY/balance`
+`GET /organizations/us/accounts/PRELIMINARY/balance`
 
 ```json
 {
@@ -36,7 +36,7 @@ until (optional):: used to get the balance at a specific point in history (ignor
 ```
 
 ### Account Transactions
-`GET organizations/us/accounts/{accountTypeGroup}/transactions`
+`GET /organizations/us/accounts/{accountTypeGroup}/transactions`
 
 accountTypeGroup:: Which accounts types to get data from. Either `LIQUID` or `PRELIMINARY`.
 includeTransactionType:: Which transaction types to include. Multiple values allowed. Valid values:
@@ -74,7 +74,7 @@ offset (optional):: Offset the result set by X number of results.
 `READ:FINANCE`
 
 #### Example Response
-`GET organizations/us/accounts/LIQUID/transactions?start=2015-11-16&end=2015-11-17`
+`GET /organizations/us/accounts/LIQUID/transactions?start=2015-11-16&end=2015-11-17`
 
 ```json
 {
@@ -118,7 +118,7 @@ Finance transactions of types `CARD_PAYMENT`, `CARD_PAYMENT_FEE`, `CARD_REFUND` 
 In the case of other transaction types, the value of the `originatingTransactionUuid` is not linkable to a specific card purchase and is not useful for external integrators.
 
 ### Payouts
-`GET organizations/us/payout-info`
+`GET /organizations/us/payout-info`
 
 at (optional):: Use to get payouts until a specific historic date. Formatted as an ISO 8601 string.
 
@@ -126,7 +126,7 @@ at (optional):: Use to get payouts until a specific historic date. Formatted as 
 `READ:FINANCE`
 
 #### Example Response
-`GET organizations/us/payout-info`
+`GET /organizations/us/payout-info`
 ```json
 {
     "data": {

--- a/finance.adoc
+++ b/finance.adoc
@@ -59,14 +59,14 @@ FEE_DISCOUNT_REVOCATION::: An internal reclaim of outstanding fee discount money
 CARD_PAYMENT_FEE::: References the commission part of a card payment.
 CARD_PAYMENT_FEE_REFUND::: References the commission part of a refund.
 ADVANCE::: References the cash advance given by iZettle to a merchant.
-A cash advance is a type of financing that is offered to merchant's based on their sales history. The advance is paid back with monthly downpayments.
-ADVANCE_FEE::: References the the fee that iZettle charges when giving a cash advance.
-ADVANCE_DOWNPAYMENT::: A downpayment on a previously paid out cash advance
+A cash advance is a type of financing that is offered to merchant's based on their sales history. The advance is paid back with monthly down payment.
+ADVANCE_FEE::: References the fee that iZettle charges when giving a cash advance.
+ADVANCE_DOWNPAYMENT::: A down payment on a previously paid out cash advance.
 ADVANCE_FEE_DOWNPAYMENT::: References the netting of a cash advance fee.
 SUBSCRIPTION_CHARGE::: References a subscription charge (e.g. for the Kassaregister service).
 
-start:: a start point in time, limiting the result set (inclusive).
-end:: an end point in time, limiting the result set (exclusive).
+start:: A start point in time, limiting the result set (inclusive). Formatted as an ISO 8601 string.
+end:: An end point in time, limiting the result set (exclusive). Formatted as an ISO 8601 string.
 limit (optional):: Limit the result set to X number of results.
 offset (optional):: Offset the result set by X number of results.
         
@@ -120,12 +120,12 @@ In the case of other transaction types, the value of the `originatingTransaction
 ### Payouts
 `GET organizations/us/payout-info`
 
-at (optional):: Use to get payouts until a specific historic DateTime.
+at (optional):: Use to get payouts until a specific historic date. Formatted as an ISO 8601 string.
 
-#### Permissions required
+#### Permissions Required
 `READ:FINANCE`
 
-#### Example response
+#### Example Response
 `GET organizations/us/payout-info`
 ```json
 {

--- a/inventory.adoc
+++ b/inventory.adoc
@@ -26,7 +26,7 @@ SUPPLIER > STORE
 `BIN & SOLD` are abstractions for when a product is sold or discarded.
 
 An important note is that you cannot directly set a stock balance for a variant.
-If you want to set an absolute value to a variant you need to calculate the change needed to reach that stock value.
+If you want to set an absolute value of a variant you need to calculate the change needed to reach that stock value.
 
 #### Example 1:
 `PUT /organizations/{organizationUuid}/inventory`

--- a/product-library.adoc
+++ b/product-library.adoc
@@ -12,7 +12,7 @@ https://products.izettle.com/swagger
 ---
 ### Example Requests
 #### Create product
-`POST https://products.izettletest.com/organizations/self/products`
+`POST /organizations/self/products`
 
 https://products.izettle.com/swagger/#!/products/createProduct
 ```json
@@ -54,7 +54,7 @@ https://products.izettle.com/swagger/#!/products/createProduct
 ---
 
 #### Update product
-`PUT https://products.izettletest.com/organizations/self/products/v2/{productUuid}`
+`PUT /organizations/self/products/v2/{productUuid}`
 
 https://products.izettle.com/swagger/#!/products/updateFullProduct
 

--- a/purchase.adoc
+++ b/purchase.adoc
@@ -1,7 +1,7 @@
 ## Purchase API V1
 
 ### Service Description
-The purchase API provides information about a purchases made through the iZettle point-of-sale.
+The purchase API provides information about purchases made through the iZettle point-of-sale.
 
 ### URL
 https://purchase.izettle.com
@@ -24,8 +24,8 @@ Will include cash register information if possible.
 `GET /purchases`
 
 lastPurchaseHash (optional):: A value from "lastPurchaseHash" from the result of a previous history query, to continue listing purchases from the next record after the previous query.
-startDate (optional):: Start date for purchases to be retrieved from, and including, this day until today or endDate. Can only be combined with endDate or limit.
-endDate (optional):: Last date, exclusive, for purchases to be retrieved until. Can only be combined with startDate.
+startDate (optional):: The start date (inclusive) for purchases to be retrieved from until today or endDate. Can only be combined with endDate or limit.
+endDate (optional):: The last date (exclusive) for purchases to be retrieved until. Can only be combined with startDate.
 limit (optional):: The maximum number of records to return.
 descending (optional):: When true, returns purchases with the highest timestamp first.  When false, returns purchases with the lowest timestamp first. Defaults to false if not specified.
 

--- a/purchase.adoc
+++ b/purchase.adoc
@@ -21,7 +21,7 @@ ____
 === Get purchase history
 Will include cash register information if possible.
 
-`GET purchases`
+`GET /purchases`
 
 lastPurchaseHash (optional):: A value from "lastPurchaseHash" from the result of a previous history query, to continue listing purchases from the next record after the previous query.
 startDate (optional):: Start date for purchases to be retrieved from, and including, this day until today or endDate. Can only be combined with endDate or limit.
@@ -38,7 +38,7 @@ Fields named "*UUID1" are the standard UUID Type 1 (8-4-4-4-12) representation o
 `READ:PURCHASE`
 
 #### Example response 1
-`GET purchases?limit=10`
+`GET /purchases?limit=10`
 ```json
 {
   "purchases": [
@@ -365,7 +365,7 @@ Fields named "*UUID1" are the standard UUID Type 1 (8-4-4-4-12) representation o
 
 ### Get purchase details
 
-`GET purchase/{purchaseUUID}`
+`GET /purchase/{purchaseUUID}`
 
 #### Permissions required
 `READ:PURCHASE`
@@ -376,7 +376,7 @@ purchaseUUID:: The UUID of the purchase
 404:: Purchase not found
 
 #### Example response
-`GET purchase/6HbDrnUNRji5iniGikNLiQ`
+`GET /purchase/6HbDrnUNRji5iniGikNLiQ`
 ```json
 {
     "purchaseUUID": "6HbDrnUNRji5iniGikNLiQ",


### PR DESCRIPTION
Just some super minor spelling/grammar fixes + clarifying the format of date parameters (I thought this was a bit unclear when reading the docs). I made the assumption that ISO 8601 should be used from reading the code - but it looks like non-ISO 8601 formats might work too as there most likely are some heuristics in place that manages to parse strings that are unambiguous 🤷‍♂️