### PR TITLE
Remove reference to unofficial PHP library

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,3 @@
 ## Credentials
 Apply for API credentials here: https://www.izettle.com/api-access/
 
-## Implementations
-[PHP 7.1](https://github.com/LauLamanApps/iZettleApi/) (unofficial)


### PR DESCRIPTION
It has turned out that the https://github.com/LauLamanApps/iZettleApi/ does not have direct support for purchase history paging, so we should better not encourage third parties to use it in current state since it can cause heavy load on our purchase history endpoints.  