### PR TITLE
CU-254 initial draft for documenting public giftcard api

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ These are the documentation pages for the iZettle Go APIs.
  - [Inventory](inventory.adoc)
  - [Image](image.adoc)
  - [Pusher (Webhooks)](pusher.adoc)
+ - [Giftcard](giftcard.adoc)
 
 ## Credentials
 Apply for API credentials here: https://developer.izettle.com/register

--- a/giftcard.adoc
+++ b/giftcard.adoc
@@ -24,7 +24,7 @@ uuid:: The UUID of the giftcard
 404:: Giftcard not found
 
 #### Example response
-`GET /organizations/{organizationUuid}/giftcards/external/e876c3ae-750d-4638-b98a-78868a434b89`
+`GET /organizations/self/giftcards/external/e876c3ae-750d-4638-b98a-78868a434b89`
 ```json
 {
   "uuid": "e876c3ae-750d-4638-b98a-78868a434b89",

--- a/giftcard.adoc
+++ b/giftcard.adoc
@@ -13,7 +13,7 @@ The Giftcard API implements the following scopes:
 
 ### Get Giftcard details
 
-`GET organizations/{organizationUuid}/giftcards/external/{uuid}`
+`GET organizations/self/giftcards/external/{uuid}`
 
 #### Permissions required
 `READ:PURCHASE`

--- a/giftcard.adoc
+++ b/giftcard.adoc
@@ -1,0 +1,46 @@
+## Giftcard API
+
+### Service Description
+The Giftcard API provides extra information about purchases made through iZettle with a giftcard.
+
+### URL
+https://giftcard.izettle.com
+
+### Scopes
+The Giftcard API implements the following scopes:
+
+- `READ:PURCHASE`
+
+### Get Giftcard details
+
+`GET organizations/{organizationUuid}/giftcards/external/{uuid}`
+
+#### Permissions required
+`READ:PURCHASE`
+
+uuid:: The UUID of the giftcard
+
+#### Errors
+404:: Giftcard not found
+
+#### Example response
+`GET /organizations/{organizationUuid}/giftcards/external/e876c3ae-750d-4638-b98a-78868a434b89`
+```json
+{
+  "uuid": "e876c3ae-750d-4638-b98a-78868a434b89",
+  "created": "2015-02-08",
+  "validTo": "2017-02-08",
+  "initialAmount": 1500,
+  "remainingAmount": 900
+}
+```
+
+### Giftcards
+
+=== Giftcard attributes
+The `giftcards` data type only contain a few generic parameters such as `uuid`, `amount` and `dates`.
+
+- `created` the date that the giftcard was created
+- `validTo` once this date has passed the giftcard will be expired and can no longer be used
+- `initialAmount` the amount that the giftcard was initially loaded with
+- `remainingAmount` current balance of the giftcard

--- a/purchase.adoc
+++ b/purchase.adoc
@@ -458,7 +458,7 @@ A purchase has one or more payments represented in the `payments` list attribute
 === Payment attributes
 The `payment` data type only contain a few generic parameters such as `uuid`, `amount` and `type`.
 
-The currently available payment types are `IZETTLE_CARD`, `IZETTLE_CARD_ONLINE`, `IZETTLE_CASH`, `IZETTLE_INVOICE`, `SWISH`, `VIPPS`, `MOBILE_PAY`, `PAYPAL`, `STORE_CREDIT` and `CUSTOM`.
+The currently available payment types are `IZETTLE_CARD`, `IZETTLE_CARD_ONLINE`, `IZETTLE_CASH`, `IZETTLE_INVOICE`, `SWISH`, `VIPPS`, `MOBILE_PAY`, `PAYPAL`, `STORE_CREDIT`, `GIFTCARD` and `CUSTOM`.
 Payment types are added when product offerings at iZettle changes, so for forwards-compatibility it is important that clients are tolerant of receiving payments of types that are not defined upfront.
 
 To be able to represent all types of payments it has an `attributes` map that contain all payment type specific data such as `maskedPan` or `cardType` for card payments or `handedAmount` for cash payments.


### PR DESCRIPTION
- api doc added, main purpose is for supporting accounting integrations 
- Added GIFTCARD as a type in purchase api

Some outstanding questions

- okay to reuse scope **READ:PURCHASE** 
- api-path (naming), most other don't involve **organizations** and **external** is it a good name
- do we need to time publishing this with actual service

