### PR TITLE
finance: add PAYMENT and PAYMENT_FEE

### DIFF
--- a/finance.adoc
+++ b/finance.adoc
@@ -70,6 +70,8 @@ ADVANCE_FEE_DOWNPAYMENT::: References the netting of a cash advance fee.
 SUBSCRIPTION_CHARGE::: References a subscription charge (e.g. for the Kassaregister service).
 INVOICE_PAYMENT::: References an invoice payment.
 INVOICE_PAYMENT_FEE::: References an invoice payment fee.
+PAYMENT::: References an alternative, third-party, payment method where iZettle handles the funds.
+PAYMENT_FEE::: References the fee for a third-party payment method.
 ADJUSTMENT::: References a bookkeeping adjustment.
 
 start:: A start point in time, limiting the result set (inclusive). Formatted as an ISO 8601 string.


### PR DESCRIPTION
Add payments type `PAYMENT` and `PAYMENT_FEE` to the docs. 

These payments are being returned by the API and it's not documented, which is making some integrators confused.