### PR TITLE
update purchase.adoc

### DIFF
--- a/purchase.adoc
+++ b/purchase.adoc
@@ -6,6 +6,9 @@ The purchase API provides information about purchases made through iZettle.
 ### URL
 https://purchase.izettle.com
 
+### API Documentation
+<https://purchase.izettle.com/swagger>
+
 ### Scopes
 The Purchase API implements the following scopes:
 


### PR DESCRIPTION
Added the swagger url to the documentation to match the format of the other docs in this repo. Also This change helps people locate the swagger from this page.