### PR TITLE
Add missing Swagger links

### DIFF
--- a/giftcard.adoc
+++ b/giftcard.adoc
@@ -6,6 +6,9 @@ The Giftcard API provides extra information about purchases made through iZettle
 ### URL
 https://giftcard.izettle.com
 
+### API Documentation
+https://giftcard.izettle.com/swagger
+
 ### Scopes
 The Giftcard API implements the following scopes:
 

--- a/purchase.adoc
+++ b/purchase.adoc
@@ -6,6 +6,9 @@ The purchase API provides information about purchases made through iZettle.
 ### URL
 https://purchase.izettle.com
 
+### API Documentation
+https://purchase.izettle.com/swagger
+
 ### Scopes
 The Purchase API implements the following scopes:
 


### PR DESCRIPTION
I don't know why Giftcards and Purchase API documentations don't contain Swagger links, but others do, so I figured they might be missing.