### PR TITLE
Fix error type when using an invalid refresh_token

### DIFF
--- a/authorization.adoc
+++ b/authorization.adoc
@@ -147,7 +147,7 @@ The Authorization OAuth2 API will return errors when retrieving and refreshing a
 ```
 HTTP 400 Bad Request
 {
-    "error": "invalid_request",
+    "error": "invalid_grant",
     "error_description": "invalid refresh_token"
 }
 ```


### PR DESCRIPTION
This has changed recently in Authorization service to comply with the standard error codes from the [OAuth2.0 RFC](https://tools.ietf.org/html/rfc6749#section-5.2).