### PR TITLE
Changed to Zettle Go since app's name is "Zettle Go" now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# iZettle Go API Beta Documentation
+# Zettle Go API Beta Documentation
 
-These are the beta documentation pages for the iZettle Go APIs.
+These are the beta documentation pages for the Zettle Go APIs.
 
 -   [Changelog](CHANGELOG.adoc)
 -   [Frequently Asked Questions](faq.adoc)


### PR DESCRIPTION
![Screenshot 2021-02-22 at 11 35 28](https://user-images.githubusercontent.com/42367412/108696657-23722680-7502-11eb-91b8-93187efabf30.png)
