### PR TITLE
Removed supported markets for third party payments

### DIFF
--- a/finance.adoc
+++ b/finance.adoc
@@ -123,8 +123,8 @@ A cash advance is a type of financing that is offered to merchants based on thei
 |ADVANCE_FEE_DOWNPAYMENT|References the netting of a cash advance fee.
 |INVOICE_PAYMENT |References an invoice payment.
 |INVOICE_PAYMENT_FEE |References an invoice payment fee.
-|PAYMENT |References an alternative, third-party, payment method where iZettle handles the funds e.g. PayPal QR code(only DE and FR), Klarna QR code(only SE, FI, DK and NO).
-|PAYMENT_FEE |References the fee for a third-party payment method e.g PayPal QR code(only DE and FR), Klarna QR code(only SE, FI, DK and NO).
+|PAYMENT |References an alternative, third-party, payment method where iZettle handles the funds e.g. PayPal QR code, Klarna QR code.
+|PAYMENT_FEE |References the fee for a third-party payment method e.g PayPal QR code, Klarna QR code.
 |ADJUSTMENT |References a bookkeeping adjustment.
 |===
 


### PR DESCRIPTION
Removed supported markets for third party payments since it's hard to keep up to date.