### PR TITLE
[Workaround]Changed default details behaviour to open for sections

### DIFF
--- a/finance.adoc
+++ b/finance.adoc
@@ -28,7 +28,7 @@ After a deposit has been made from `LIQUID` account to merchant's bank account (
 If not, it will return the amount that is still due in merchant's iZettle account.
 
 `GET /organizations/{organizationUuid}/accounts/{accountTypeGroup}/balance`
-[%collapsible%open]
+[%collapsible]
 ====
 
 *Parameters*
@@ -74,7 +74,7 @@ _Response:_
 Returns a list of transactions for given account and period.
 
 `GET /organizations/{organizationUuid}/accounts/{accountTypeGroup}/transactions`
-[%collapsible%open]
+[%collapsible]
 ====
 
 *Parameters*
@@ -419,7 +419,7 @@ Returns payout related information for an organization.
 
 `GET /organizations/{organizationUuid}/payout-info`
 
-[%collapsible%open]
+[%collapsible]
 ====
 *Parameters*
 

--- a/finance.adoc
+++ b/finance.adoc
@@ -28,7 +28,7 @@ After a deposit has been made from `LIQUID` account to merchant's bank account (
 If not, it will return the amount that is still due in merchant's iZettle account.
 
 `GET /organizations/{organizationUuid}/accounts/{accountTypeGroup}/balance`
-[%collapsible]
+[%collapsible%open]
 ====
 
 *Parameters*
@@ -74,7 +74,7 @@ _Response:_
 Returns a list of transactions for given account and period.
 
 `GET /organizations/{organizationUuid}/accounts/{accountTypeGroup}/transactions`
-[%collapsible]
+[%collapsible%open]
 ====
 
 *Parameters*
@@ -419,7 +419,7 @@ Returns payout related information for an organization.
 
 `GET /organizations/{organizationUuid}/payout-info`
 
-[%collapsible]
+[%collapsible%open]
 ====
 *Parameters*
 

--- a/finance.adoc
+++ b/finance.adoc
@@ -2,7 +2,7 @@
 
 == Description
 ====
-Finance APIs return information about monetary transactions where money has passed through iZettle, such transactions can be e.g. card payments, card fees, payouts to the merchant etc.
+Finance APIs return information about monetary transactions where money has passed through Zettle, such transactions can be e.g. card payments, card fees, payouts to the merchant etc.
 ====
 === Base URL
 https://finance.izettle.com
@@ -25,7 +25,7 @@ https://finance.izettle.com
 ==== Fetch account balance
 Returns accumulated balance at a specific point in time. +
 After a deposit has been made from `LIQUID` account to merchant's bank account (daily, monthly or weekly), the balance is usually zero.
-If not, it will return the amount that is still due in merchant's iZettle account.
+If not, it will return the amount that is still due in merchant's Zettle account.
 
 `GET /organizations/{organizationUuid}/accounts/{accountTypeGroup}/balance`
 [%collapsible]
@@ -102,28 +102,28 @@ e.g. "2020-11-29T03:10:02" or "2020-08-14".
 
 |CARD_PAYMENT|References a card payment. Contains a reference to the card payment in the Purchase API.
 |CARD_REFUND |References a card refund. Will be accompanied by a `CARD_PAYMENT_FEE_REFUND` that will void the card fee. Contains a reference to the card payment refund in the Purchase API.
-|BANK_ACCOUNT_VERIFICATION |References a transaction which is a refund of the money transferred to the iZettle bank account as a verification of ownership of the nominated bank account, made by the merchant.
+|BANK_ACCOUNT_VERIFICATION |References a transaction which is a refund of the money transferred to the Zettle bank account as a verification of ownership of the nominated bank account, made by the merchant.
 The transaction happens only when the merchant has nominated and verified a new bank account for payouts.
 |PAYOUT |A payout to the merchant's bank account.
-|FAILED_PAYOUT |A previous `PAYOUT` transaction has failed and is voided by this transaction (money going back to the merchant's liquid account at iZettle).
+|FAILED_PAYOUT |A previous `PAYOUT` transaction has failed and is voided by this transaction (money going back to the merchant's liquid account at Zettle).
 |CASHBACK |Money given to a merchant to retroactively adjust the card payment fee rate.
 |+++<s>CASHBACK_PAYOUT</s>+++ |Direct payout of a cashback, effectively circumventing the normal flow via the liquid account *(Deprecated)*.
 |VOUCHER_ACTIVATION |Used when activating a voucher (money is inserted to the merchant's fee discount account). These transactions will never appear in the `LIQUID` account.
-|EMONEY_TRANSFER |An internal transfer between two merchants' iZettle accounts. Only used in Sweden.
-|+++<s>TELL_FRIEND</s>+++ |Money given to a merchant for recommending iZettle *(Deprecated)*.
+|EMONEY_TRANSFER |An internal transfer between two merchants' Zettle accounts. Only used in Sweden.
+|+++<s>TELL_FRIEND</s>+++ |Money given to a merchant for recommending Zettle *(Deprecated)*.
 |FROZEN_FUNDS |In the event of a chargeback initiated by the issuing bank, funds will be removed from the merchant liquid account and marked as frozen, to cover the chargeback.
 If the chargeback is later revoked, the money will be returned to the merchants liquid account with a new, positive, transaction of the same type, effectively voiding the initial
 FROZEN_FUNDS transaction.
 |FEE_DISCOUNT_REVOCATION |An internal reclaim of outstanding fee discount money if the customer has not consumed the discount within a certain time frame. As these funds are reclaimed from a special fee discount account, the transaction will not be visible on the liquid account.
 |CARD_PAYMENT_FEE |References the commission part of a card payment.
 |CARD_PAYMENT_FEE_REFUND |References the commission part of a refund.
-|ADVANCE |References the cash advance given by iZettle to a merchant.
+|ADVANCE |References the cash advance given by Zettle to a merchant.
 A cash advance is a type of financing that is offered to merchants based on their sales history. The advance is paid back with monthly down payments.
 |ADVANCE_DOWNPAYMENT |A down payment on a previously paid out cash advance.
 |ADVANCE_FEE_DOWNPAYMENT|References the netting of a cash advance fee.
 |INVOICE_PAYMENT |References an invoice payment.
 |INVOICE_PAYMENT_FEE |References an invoice payment fee.
-|PAYMENT |References an alternative, third-party, payment method where iZettle handles the funds e.g. PayPal QR code(only DE and FR), Klarna QR code(only SE, FI, DK and NO).
+|PAYMENT |References an alternative, third-party, payment method where Zettle handles the funds e.g. PayPal QR code(only DE and FR), Klarna QR code(only SE, FI, DK and NO).
 |PAYMENT_FEE |References the fee for a third-party payment method e.g PayPal QR code(only DE and FR), Klarna QR code(only SE, FI, DK and NO).
 |ADJUSTMENT |References a bookkeeping adjustment.
 |===

--- a/purchase.adoc
+++ b/purchase.adoc
@@ -372,7 +372,7 @@ Example:
 |SWISH|Alternative payment method available in Sweden, has no additional attributes.
 |VIPPS|Alternative payment method  available in Norway, has no additional attributes.
 |MOBILE_PAY|Alternative payment method available in Denmark, has no additional attributes.
-|PAYPAL a| Payment made with PayPal wallet, available in France and Germany.
+|PAYPAL a| Payment made with PayPal wallet.
 
 Example:
 [source,json]
@@ -388,7 +388,7 @@ Example:
 ----
 |STORE_CREDIT|Store credit is usually a document offered by a store to a customer who returns an item not eligible for a refund or when a customer doesn't want to get chargeback on credit card that was used. It can be used to buy other goods at the same store.
 |GIFTCARD|Payment made with a gift card(certificate/voucher) issued by the merchant.
-|KLARNA a|Alternative payment method available in Sweden, Denmark, Finland, Norway and Germany.
+|KLARNA a|Payment made with Klarna.
 
 Example:
 [source,json]

--- a/purchase.adoc
+++ b/purchase.adoc
@@ -24,7 +24,7 @@ See <<example1>>.
 
 === Parameters
 .Parameters
-[%collapsible]
+[%collapsible%open]
 ====
 [cols="15%,10%,10%,10%,55%"]
 |===
@@ -42,7 +42,7 @@ By default `startDate` is resolved to three years back.
 === Responses
 .Response codes
 
-[%collapsible]
+[%collapsible%open]
 ====
 [cols="30%,70%"]
 |===
@@ -55,7 +55,7 @@ By default `startDate` is resolved to three years back.
 ====
 
 .Response attributes
-[%collapsible]
+[%collapsible%open]
 ====
 [cols="20%,20%,60%"]
 |===
@@ -85,7 +85,7 @@ See <<example4>>.
 
 === Parameters
 .Parameters
-[%collapsible]
+[%collapsible%open]
 ====
 [cols="15%,10%,10%,10%,55%"]
 |===
@@ -97,7 +97,7 @@ See <<example4>>.
 
 === Responses
 .Response codes
-[%collapsible]
+[%collapsible%open]
 ====
 [cols="30%,70%"]
 |===
@@ -112,7 +112,7 @@ See <<example4>>.
 
 [#Purchase]
 .Response attributes
-[%collapsible]
+[%collapsible%open]
 ====
 .Purchase attributes
 [cols="20%,20%,60%"]

--- a/pusher-api/api-reference.md
+++ b/pusher-api/api-reference.md
@@ -65,8 +65,8 @@ See [Create a webhook subscription example](#create-a-webhook-subscription).
 
 ### Parameters
 
-<details><!-- start tag of the Parameters section-->
-<summary>Click to see all request parameters for creating a subscription.</summary>
+<details open="true"><!-- start tag of the Parameters section-->
+<summary>Click to hide all request parameters for creating a subscription.</summary>
 
 |Name |Type |In |Required/Optional |Description
 |---- |---- |---- |---- |----
@@ -80,8 +80,8 @@ See [Create a webhook subscription example](#create-a-webhook-subscription).
 
 
 ### Responses
-<details>
-<summary name="createHttpStatusCode">Click to see HTTP status codes.</summary>
+<details open="true">
+<summary name="createHttpStatusCode">Click to hide HTTP status codes.</summary>
 
 |Status code |Description
 |---- |----
@@ -93,8 +93,8 @@ See [Create a webhook subscription example](#create-a-webhook-subscription).
 |500 Internal Server Error|Returned when one of the following occurs: <br/><ul><li>The `destination` responded with a non-successful HTTP response code.</li><li>The service encountered an internal server error. In case this error persists, contact [support](mailto:api@zettle.com).</li></ul>
 </details>
 
-<details>
-<summary>Click to see response attributes.</summary>
+<details open="true">
+<summary>Click to hide response attributes.</summary>
 <p>A successful <code>200 OK</code> response will have the following attributes:</p>
 
 |Name |Type |Description
@@ -122,8 +122,8 @@ See [Get webhook subscriptions example](#get-webhook-subscriptions).
 
 ### Parameters
 
-<details>
-<summary>Click to see all request parameters for getting all subscriptions.</summary>
+<details open="true">
+<summary>Click to hide all request parameters for getting all subscriptions.</summary>
 
 |Name |Type |In |Required/Optional |Description
 |---- |---- |---- |---- |----
@@ -132,8 +132,8 @@ See [Get webhook subscriptions example](#get-webhook-subscriptions).
 
 
 ### Responses
-<details>
-<summary>Click to see HTTP status codes.</summary>
+<details open="true">
+<summary>Click to hide HTTP status codes.</summary>
 
 |Status code |Description
 |---- |----
@@ -144,8 +144,8 @@ See [Get webhook subscriptions example](#get-webhook-subscriptions).
 
 
 
-<details>
-<summary>Click to see response attributes.</summary>
+<details open="true">
+<summary>Click to hide response attributes.</summary>
 <p>A successful <code>200 OK</code> response will return an array of subscriptions. Each subscription contains the following response attributes:</p>
 
 
@@ -173,8 +173,8 @@ See [Update a webhook subscription example](#update-a-webhook-subscription).
 
 ### Parameters
 
-<details>
-<summary>Click to see all request parameters for updating a subscription.</summary>
+<details open="true">
+<summary>Click to hide all request parameters for updating a subscription.</summary>
 
 |Name |Type |In |Required/Optional |Description
 |---- |---- |---- |---- |----
@@ -188,8 +188,8 @@ See [Update a webhook subscription example](#update-a-webhook-subscription).
 
 
 ### Responses
-<details>
-<summary name="updateHttpStatusCode">Click to see HTTP status codes.</summary>
+<details open="true">
+<summary name="updateHttpStatusCode">Click to hide HTTP status codes.</summary>
 
 |Status code |Description
 |---- |----
@@ -202,8 +202,8 @@ See [Update a webhook subscription example](#update-a-webhook-subscription).
 |500 Internal Server Error| Returned when the service encounters an internal server error. In case this error persists, contact [support](mailto:api@zettle.com).
 </details>
 
-<details>
-<summary>Click to see response attributes.</summary><br/>
+<details open="true">
+<summary>Click to hide response attributes.</summary><br/>
 <p>The service returns a <code>200 OK</code> response without any content.</p>
 </details>
 
@@ -220,8 +220,8 @@ See [Delete a webhook subscription example](#delete-a-webhook-subscription).
 
 ### Parameters
 
-<details>
-<summary>Click to see all request parameters for deleting a subscription.</summary>
+<details open="true">
+<summary>Click to hide all request parameters for deleting a subscription.</summary>
 
 |Name |Type |In |Required/Optional |Description
 |---- |---- |---- |---- |----
@@ -231,8 +231,8 @@ See [Delete a webhook subscription example](#delete-a-webhook-subscription).
 
 
 ### Responses
-<details>
-<summary name="deleteHttpStatusCode">Click to see HTTP status codes.</summary>
+<details open="true">
+<summary name="deleteHttpStatusCode">Click to hide HTTP status codes.</summary>
 
 |Status code |Description
 |---- |----
@@ -242,15 +242,15 @@ See [Delete a webhook subscription example](#delete-a-webhook-subscription).
 |500 Internal Server Error| Returned when the service encounters an internal server error. In case this error persists, contact [support](mailto:api@zettle.com).
 </details>
 
-<details>
-<summary>Click to see response attributes.</summary><br/>
+<details open="true">
+<summary>Click to hide response attributes.</summary><br/>
 <p>The service returns a <code>204 No Content</code> response without any content.</p>
 </details>
 
 ## Supported events
 
-<details>
-<summary>Click to see a list all the events supported by the service and their corresponding authorization scopes.</summary>
+<details open="true">
+<summary>Click to hide a list all the events supported by the service and their corresponding authorization scopes.</summary>
 
 |Event name |Required scope | Trigger
 |---- |---- |----

--- a/pusher-api/user-guides/create-subscriptions.md
+++ b/pusher-api/user-guides/create-subscriptions.md
@@ -23,8 +23,6 @@ For every subscription, generate a version 1 Universally Unique Identifier (UUID
 
 1. Generate a version 1 UUID. For example, you can use [UUID Generator](https://www.uuidgenerator.net/version1) to generate a version 1 UUID. <!-- how to treat 3rd party resources at Zettle? -->
 
-> **Disclaimer:** The UUID Generator is a third-party resource that Zettle has no liability for the availability and intellectual property claims.
-
 2. Copy and save the UUID. It will be used for creating a subscription.
 
 ## Step 2: Test webhooks
@@ -34,8 +32,6 @@ Before creating subscriptions to the HTTPS endpoint on your app, test the events
     * You can use the destination URL that you have set up on your server.
     * If you run a local server, you can make it publicly available using [ngrok](https://ngrok.com/).
     * If you don't run a local server, you can use [Webhook.site](https://webhook.site) that provides an online view of all requests. <!-- how to treat 3rd party resources at Zettle? -->
-
-> **Disclaimer:** The Ngrok and Webhook.site are third-party resources that Zettle has no liability for the availability and intellectual property claims.
 
 2. Follow [Step 3: Create a subscription](#step-3-create-a-subscription) to test the events and check the payloads.
 

--- a/pusher-api/user-guides/create-subscriptions.md
+++ b/pusher-api/user-guides/create-subscriptions.md
@@ -119,8 +119,8 @@ To verify that events come from Zettle, calculate a signature and compare it wit
 
      <!-- what's the prerequisite for using the code? -->
 
-    <details open="true">
-      <summary>Click to hide a Python 2 example.</summary>
+    <details>
+      <summary>Click to see a Python 2 example.</summary>
         
       ```python
         import hmac
@@ -132,8 +132,8 @@ To verify that events come from Zettle, calculate a signature and compare it wit
        
     </details>
        
-    <details open="true">
-      <summary>Click to hide a Python 3 example.</summary>
+    <details>
+      <summary>Click to see a Python 3 example.</summary>
            
       ```python
         import hmac
@@ -144,8 +144,8 @@ To verify that events come from Zettle, calculate a signature and compare it wit
       ```    
     </details>
         
-    <details open="true">
-      <summary>Click to hide a PHP example.</summary>
+    <details>
+      <summary>Click to see a PHP example.</summary>
            
       ```php
         $payloadToSign = stripslashes($timestamp . '.' . $payloadStr);
@@ -154,8 +154,8 @@ To verify that events come from Zettle, calculate a signature and compare it wit
           
     </details> 
     
-    <details open="true">
-      <summary>Click to hide a Java example.</summary>
+    <details>
+      <summary>Click to see a Java example.</summary>
            
       ```java
         import javax.crypto.Mac;

--- a/pusher-api/user-guides/create-subscriptions.md
+++ b/pusher-api/user-guides/create-subscriptions.md
@@ -119,8 +119,8 @@ To verify that events come from Zettle, calculate a signature and compare it wit
 
      <!-- what's the prerequisite for using the code? -->
 
-    <details>
-      <summary>Click to see a Python 2 example.</summary>
+    <details open="true">
+      <summary>Click to hide a Python 2 example.</summary>
         
       ```python
         import hmac
@@ -132,8 +132,8 @@ To verify that events come from Zettle, calculate a signature and compare it wit
        
     </details>
        
-    <details>
-      <summary>Click to see a Python 3 example.</summary>
+    <details open="true">
+      <summary>Click to hide a Python 3 example.</summary>
            
       ```python
         import hmac
@@ -144,8 +144,8 @@ To verify that events come from Zettle, calculate a signature and compare it wit
       ```    
     </details>
         
-    <details>
-      <summary>Click to see a PHP example.</summary>
+    <details open="true">
+      <summary>Click to hide a PHP example.</summary>
            
       ```php
         $payloadToSign = stripslashes($timestamp . '.' . $payloadStr);
@@ -154,8 +154,8 @@ To verify that events come from Zettle, calculate a signature and compare it wit
           
     </details> 
     
-    <details>
-      <summary>Click to see a Java example.</summary>
+    <details open="true">
+      <summary>Click to hide a Java example.</summary>
            
       ```java
         import javax.crypto.Mac;


### PR DESCRIPTION
The default behaviour with the `details` tag is `collapsed`, which causes problems with search and cross-reference links within the tag.
For the time being, we changed the default behaviour to `open` for sections, as search and cross-references are seldom set with content in code snippets and examples.