### PR TITLE
Fix broken swagger links for 'inventory' and 'products' endpoint

### DIFF
--- a/inventory-api/concepts/how-inventories-work.md
+++ b/inventory-api/concepts/how-inventories-work.md
@@ -8,7 +8,7 @@ Inventory management includes tracking of inventory levels, orders, and sales ac
 `https://inventory.izettle.com`
 
 ### API documentation
-https://inventory.izettle.com/swagger
+https://inventory.izettle.com/swagger/#!
 
 ### OAuth scope
 The Inventory API requires the following scopes:

--- a/product-library.adoc
+++ b/product-library.adoc
@@ -8,7 +8,7 @@ items in a product library.
 Service endpoint URL: https://products.izettle.com
 
 ### API documentation
-API specification: https://products.izettle.com/swagger
+API specification: https://products.izettle.com/swagger/#!
 
 ### Scopes
 The Product Library API implements the following scopes:


### PR DESCRIPTION
I was exploring the documentation and found what seem to be broken links to swagger. It's weird given that I had previously accessed those links without issues. Maybe it's due to a change in swagger backend.

### Context
When trying to access `products` or `inventory` swagger links from documentation we'd get a 406 Not Acceptable error.
Fails for me with the following browsers:
- Microsoft Edge Versión 98.0.1108.43
- Google Chrome Versión 98.0.4758.82
- Mozilla Firefox 97.0

### Steps to reproduce
A) `products` swagger link
- Access the following page: https://github.com/iZettle/api-documentation/blob/master/product-library.adoc
- Open the link in the "API documentation" section.

B) `inventory` swagger link
- Access the following page: https://github.com/iZettle/api-documentation/blob/master/inventory-api/concepts/how-inventories-work.md
- Open the link in the "API documentation" section.

This is the result for (A) and (B) independently of the browser used:
![image](https://user-images.githubusercontent.com/79703828/155005987-70461143-e785-475f-a01a-2adf6d57afed.png)
